### PR TITLE
Add eslint, jest, npm build to pre-push hook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.1"
 description = "A local API server for the Fidu desktop application"
 authors = [{name = "FirstDataUnion", email = "oli@firstdataunion.org"}]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "fastapi>=0.116.1",
     "uvicorn>=0.24.0",
@@ -69,7 +69,7 @@ filterwarnings = [
 ]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_return_any = false
 warn_unused_configs = true
 disallow_untyped_defs = false
@@ -92,7 +92,7 @@ ignore_missing_imports = false
 
 [tool.black]
 line-length = 88
-target-version = ['py38']
+target-version = ['py310']
 include = '\.pyi?$'
 extend-exclude = '''
 /(

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -41,4 +41,23 @@ mypy src/
 echo "🧪 Running pytest with coverage..."
 pytest --cov=src
 
-echo "✅ All checks completed successfully!" 
+
+# Run eslint in chat-lab
+echo "🧹 Running eslint in chat-lab"
+pushd src/apps/chat-lab
+npm run lint
+popd
+
+# Run jest in chat-lab with coverage
+echo "🔬 Running jest in chat-lab"
+pushd src/apps/chat-lab
+npm test -- --passWithNoTests --watchAll=false --coverage --coverageReporters=text --coverageReporters=lcov
+popd
+
+# Build chat-lab
+echo "🛠️ Building chat-lab"
+pushd src/apps/chat-lab
+npm run build
+popd
+
+echo "✅ All checks completed successfully!"

--- a/src/apps/chat-lab/backend/__tests__/test_cookie_management.py
+++ b/src/apps/chat-lab/backend/__tests__/test_cookie_management.py
@@ -160,12 +160,15 @@ class TestOAuthEndpoints:
                 )
 
                 # Mock encryption service methods
-                with patch(
-                    "server.encryption_service.get_user_encryption_key",
-                    new_callable=AsyncMock,
-                ) as mock_get_key, patch(
-                    "server.encryption_service.encrypt_refresh_token"
-                ) as mock_encrypt_token:
+                with (
+                    patch(
+                        "server.encryption_service.get_user_encryption_key",
+                        new_callable=AsyncMock,
+                    ) as mock_get_key,
+                    patch(
+                        "server.encryption_service.encrypt_refresh_token"
+                    ) as mock_encrypt_token,
+                ):
                     mock_get_key.return_value = "test_encryption_key"
                     mock_encrypt_token.return_value = "encrypted_refresh_token"
 
@@ -217,11 +220,12 @@ class TestOAuthEndpoints:
                 )
 
                 # Mock decryption
-                with patch(
-                    "server.decrypt_refresh_token", new_callable=AsyncMock
-                ) as mock_decrypt, patch(
-                    "server.httpx.AsyncClient"
-                ) as mock_fidu_client:
+                with (
+                    patch(
+                        "server.decrypt_refresh_token", new_callable=AsyncMock
+                    ) as mock_decrypt,
+                    patch("server.httpx.AsyncClient") as mock_fidu_client,
+                ):
                     mock_decrypt.return_value = "original_refresh_token"
 
                     # Mock FIDU identity service response

--- a/src/apps/chat-lab/package-lock.json
+++ b/src/apps/chat-lab/package-lock.json
@@ -41,7 +41,7 @@
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
         "@types/jest": "^29.5.14",
-        "@types/node": "^24.10.0",
+        "@types/node": "^24.10.1",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@types/sql.js": "^1.4.9",
@@ -112,6 +112,7 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -674,6 +675,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -717,6 +719,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1962,6 +1965,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.2.tgz",
       "integrity": "sha512-qXvbnawQhqUVfH1LMgMaiytP+ZpGoYhnGl7yYq2x57GYzcFL/iPzSZ3L30tlbwEjSVKNYcbiKO8tANR1tadjUg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.3",
         "@mui/core-downloads-tracker": "^7.3.2",
@@ -2072,6 +2076,7 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.2.tgz",
       "integrity": "sha512-9d8JEvZW+H6cVkaZ+FK56R53vkJe3HsTpcjMUtH8v1xK6Y1TjzHdZ7Jck02mGXJsE6MQGWVs3ogRHTQmS9Q/rA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.3",
         "@mui/private-theming": "^7.3.2",
@@ -2665,6 +2670,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2984,9 +2990,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
-      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3016,6 +3022,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3026,6 +3033,7 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -3154,6 +3162,7 @@
       "integrity": "sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.42.0",
         "@typescript-eslint/types": "8.42.0",
@@ -3420,6 +3429,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3584,6 +3594,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
       "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -3796,6 +3807,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -4226,7 +4238,8 @@
       "version": "1.11.18",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
       "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -4589,6 +4602,7 @@
       "integrity": "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6044,6 +6058,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8917,6 +8932,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8926,6 +8942,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -8988,6 +9005,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -9109,7 +9127,8 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-mock-store": {
       "version": "1.5.5",
@@ -9766,6 +9785,7 @@
       "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -9835,6 +9855,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10051,6 +10072,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10373,6 +10395,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10466,6 +10489,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/apps/chat-lab/package.json
+++ b/src/apps/chat-lab/package.json
@@ -46,7 +46,7 @@
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.5.14",
-    "@types/node": "^24.10.0",
+    "@types/node": "^24.10.1",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@types/sql.js": "^1.4.9",

--- a/src/apps/chat-lab/src/components/conversations/__tests__/ConversationCard.test.tsx
+++ b/src/apps/chat-lab/src/components/conversations/__tests__/ConversationCard.test.tsx
@@ -83,7 +83,7 @@ describe('ConversationCard', () => {
     
     // Test that the date is rendered (using real formatDate function)
     expect(screen.getByText(/Updated:/)).toBeInTheDocument();
-    expect(screen.getByText(/1\/1\/2024/)).toBeInTheDocument();
+    expect(screen.getByText(/0?1\/0?1\/2024/)).toBeInTheDocument();
   });
 
   it('should call onSelect when card is clicked', () => {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Add chat-lab checks to pre-push hook

Also:
* update Python to 3.10 for pytest's case matching (and pydantic req >=3.9)
* including a black re-format for 3.10
* setup_dev.sh automated package.json changes
* make one test slightly less locale-dependent

## Type of Change
<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix
- [ ] 🧪 Test addition or improvement
- [ ] 🔧 CI/CD improvement

## Testing
<!-- Describe the tests you ran and any additional testing steps -->
I pushed this!

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Frontend tests pass
- [ ] Manual testing completed
- [ ] Security scan passes

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Additional Notes
<!-- Add any other context about the pull request here -->
Interestingly, `npm test` fails if you're using worktrees because its ignore files are based from the git root, which it seems to resolve to the primary worktree.
Possibly worth fixing in the future but I don't think it's worth not doing this now for that reason.

## Related Issues
<!-- Link to any related issues -->